### PR TITLE
Use short hostname in nhc checks

### DIFF
--- a/bdist_rpm.sh
+++ b/bdist_rpm.sh
@@ -2,12 +2,18 @@
 
 PACKAGE=lbnl-nhc
 
-mkdir -p BUILD SOURCES SPECS RPMS BUILDROOT
+export BDISTRPMBASEDIR=$(pwd)/rpmbuild
+rm -Rf $BDISTRPMBASEDIR
+mkdir -p $BDISTRPMBASEDIR/{BUILD,SPECS,RPMS,SRPMS,SOURCES}
 
 ./autogen.sh
 ./configure
 make dist
-cp lbnl-nhc-*.tar.gz SOURCES
-cp ${PACKAGE}.spec "SPECS"
-rpmbuild --define "_topdir $PWD" -ba SPECS/${PACKAGE}.spec
-rm -rf BUILD SOURCES BUILDROOT SPECS
+cp -a lbnl-nhc-*.tar.gz "$BDISTRPMBASEDIR/SOURCES"
+
+rpmbuild --define "_topdir $BDISTRPMBASEDIR" -ba "${PACKAGE}.spec"
+
+rm -rf dist
+mkdir -p dist
+
+find $BDISTRPMBASEDIR -regex '.*/RPMS/.*rpm' |grep -v debuginfo |xargs -I '{}' cp -a '{}' dist

--- a/lbnl-nhc.spec.in
+++ b/lbnl-nhc.spec.in
@@ -8,7 +8,7 @@ Summary: LBNL Node Health Check
 Name: @PACKAGE@
 Version: @VERSION@
 #Release: %{_rel}%{?dist}
-Release: %{_rel}%{?dist}.ug.1
+Release: %{_rel}%{?dist}.bx.2
 License: US Dept. of Energy (BSD-like)
 Group: Applications/System
 URL: https://github.com/mej/nhc/

--- a/nhc.conf
+++ b/nhc.conf
@@ -12,6 +12,9 @@
 # Explicitly instruct NHC to assume PBS (TORQUE, PBSPro) is the Resource Manager
 * || export NHC_RM=slurm
 
+# Use the short hostname for any check (mostly important for slurm)
+* || HOSTNAME="$HOSTNAME_S"
+
 # Do not mark nodes offline
 #   * || export MARK_OFFLINE=0
 


### PR DESCRIPTION
We use the short hostname in slurm so nhc needs to use the same.