### PR TITLE
small fix of nhc.conf so that the check of ps for sshd also works on EL9

### DIFF
--- a/lbnl-nhc.spec.in
+++ b/lbnl-nhc.spec.in
@@ -1,6 +1,6 @@
 %global name    @PACKAGE@
 %global version @VERSION@
-%global release %{rel}%{?dist}.bx.2
+%global release %{rel}%{?dist}.bx.3
 
 ### Macros to populate RPM %{RELEASE} field with useful info
 # {gitrelease} holds the ./configure-generated version of the same

--- a/nhc.conf
+++ b/nhc.conf
@@ -133,7 +133,7 @@
 ### Process checks
 ###
 # Everybody needs sshd running, right?  But don't use -r (restart)!
-* || check_ps_service -u root -S sshd
+* || check_ps_service -u root -m '/sshd:?$/' -S sshd
 
 # The cron daemon is another useful critter...
 * || check_ps_service -r crond


### PR DESCRIPTION
Added a regular expression in the check_ps_service for sshd because of the extra field 'sshd:' in the output of 'ps aux' on EL9 machines. It also works on EL8.